### PR TITLE
Replace Repeat Blocks with Placeholder (Feat.)

### DIFF
--- a/src/main/java/com/github/curiousoddman/rgxgen/config/RgxGenOption.java
+++ b/src/main/java/com/github/curiousoddman/rgxgen/config/RgxGenOption.java
@@ -56,6 +56,13 @@ public class RgxGenOption<T> {
      */
     public static final RgxGenOption<List<WhitespaceChar>> WHITESPACE_DEFINITION = new RgxGenOption<>("whitespace.matches", Arrays.asList(WhitespaceChar.SPACE, WhitespaceChar.TAB));
 
+    /**
+     * Replace wildcard repeat blocks (* and +) with placeholder text instead of generating all variations.
+     *
+     * @defaultValue false
+     */
+    public static final RgxGenOption<String> REPLACE_REPEAT_BLOCKS = new RgxGenOption<>("generation.replace.repeat.blocks", null);
+
     private final String key;
     private final T      defaultValue;
 

--- a/src/main/java/com/github/curiousoddman/rgxgen/visitors/GenerationVisitor.java
+++ b/src/main/java/com/github/curiousoddman/rgxgen/visitors/GenerationVisitor.java
@@ -62,6 +62,14 @@ public class GenerationVisitor implements NodeVisitor {
 
     @Override
     public void visit(Repeat node) {
+        String replaceRepeatBlocks = RgxGenOption.REPLACE_REPEAT_BLOCKS.getFromProperties(properties);
+        
+        if (replaceRepeatBlocks != null && isWildcardRepeatBlock(node)) {
+            String placeholder = getPlaceholderForRepeatBlock(node);
+            aStringBuilder.append(placeholder);
+            return;
+        }
+        
         int max = node.getMax() == -1 ? RgxGenOption.INFINITE_PATTERN_REPETITION.getFromProperties(properties) : node.getMax();
         int repeat = node.getMin() >= max ?
                      node.getMin() :
@@ -69,6 +77,23 @@ public class GenerationVisitor implements NodeVisitor {
 
         for (int i = 0; i < repeat; ++i) {
             node.getNode().visit(this);
+        }
+    }
+    
+    private boolean isWildcardRepeatBlock(Repeat node) {
+        return (node.getMin() == 0 && node.getMax() == -1) ||  // * pattern
+               (node.getMin() == 1 && node.getMax() == -1);    // + pattern
+    }
+    
+    private String getPlaceholderForRepeatBlock(Repeat node) {
+        String pattern = node.getPattern();
+        String replaceRepeatBlocks = RgxGenOption.REPLACE_REPEAT_BLOCKS.getFromProperties(properties);
+        if (pattern.endsWith("*")) {
+            return replaceRepeatBlocks;
+        } else if (pattern.endsWith("+")) {
+            return replaceRepeatBlocks;
+        } else {
+            return "{REPEAT}";
         }
     }
 

--- a/src/main/java/com/github/curiousoddman/rgxgen/visitors/UniqueGenerationVisitor.java
+++ b/src/main/java/com/github/curiousoddman/rgxgen/visitors/UniqueGenerationVisitor.java
@@ -79,11 +79,36 @@ public class UniqueGenerationVisitor implements NodeVisitor {
 
     @Override
     public void visit(Repeat node) {
+        String replaceRepeatBlocks = RgxGenOption.REPLACE_REPEAT_BLOCKS.getFromProperties(aProperties);
+        
+        if (replaceRepeatBlocks != null && isWildcardRepeatBlock(node)) {
+            String placeholder = getPlaceholderForRepeatBlock(node);
+            aIterators.add(new SingleValueIteratorSupplier(placeholder));
+            return;
+        }
+        
         // Getting all possible sub node contents
         UniqueGenerationVisitor v = new UniqueGenerationVisitor(aReferenceIteratorMap, aGroupIterators, aProperties);
         node.getNode()
             .visit(v);
         aIterators.add(new IncrementalLengthIteratorSupplier(new PermutationsIteratorSupplier(v.aIterators), node.getMin(), node.getMax()));
+    }
+    
+    private boolean isWildcardRepeatBlock(Repeat node) {
+        return (node.getMin() == 0 && node.getMax() == -1) ||  // * pattern
+               (node.getMin() == 1 && node.getMax() == -1);    // + pattern
+    }
+    
+    private String getPlaceholderForRepeatBlock(Repeat node) {
+        String pattern = node.getPattern();
+        String replaceRepeatBlocks = RgxGenOption.REPLACE_REPEAT_BLOCKS.getFromProperties(aProperties);
+        if (pattern.endsWith("*")) {
+            return replaceRepeatBlocks;
+        } else if (pattern.endsWith("+")) {
+            return replaceRepeatBlocks;
+        } else {
+            return "{REPEAT}";
+        }
     }
 
     @Override


### PR DESCRIPTION
## Replace Repeat Blocks with Placeholder
When this property is present then instead of generating (possibly INF) iterations of the wildcard based nodes, it instead prints a placeholder String that you give it as value.

## More Detail...

* Added `REPLACE_REPEAT_BLOCKS` property (String - nullable) to the Options
* When that option is set to a String ("") then whenever a "Repeatable Node" is hit it would instead of printing X variations (based on and limited to the `INFINITE_PATTERN_REPETITION `) property then it insteads replaces said pattern with the given placeholder String that was provided in the properties.

## Example

For this pattern: `my/example/[a-zA-Z0-9]+`

Without the `REPLACE_REPEAT_BLOCKS` flag set it would do the usual generation process and generate something like:
```
my/example/aaaaa
my/example/1234
my/example/565jhsdfh3
my/example/00sdfjs1w3
etc...
```
NOW
Without the `REPLACE_REPEAT_BLOCKS` flag set it to `<___>` for example it would generate:
```
my/example/<____>
```

## Usecase 

The reason I am adding this is im basically trying to generate a templated list of acceptable strings that my code would accept (the code of course uses regex patterns). But I dont want to generate all the crazy INFINITE random versions of possible strings, instead I want something to just be put there in its place (this placeholder string) to tell the reader that this block is a Repeatable-none-specified pattern